### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/server.py
+++ b/server.py
@@ -49,7 +49,7 @@ def configure_logging():
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
 
-    logger.debug("Logging configured. Writing to %s", log_path)
+    logger.debug("Logging configured.")
     return logger
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/alebmorais/medical_automation/security/code-scanning/4](https://github.com/alebmorais/medical_automation/security/code-scanning/4)

To fix the problem, avoid logging the clear-text value of `log_path`, which is derived from a potentially sensitive environment variable. The log message at line 52 can be modified so that it does not log the actual file path. Instead, you can log a more generic message confirming that logging has been configured successfully, with an optional note of which directory is used ("default" vs. "custom") without specifying the actual path. Alternatively, given that most users do not need this detail, you may simply remove or reword the line so no sensitive information is written to the logs.

Edit only line 52 in `server.py`. No additional imports, methods, or definitions are needed. No need to update other references to `log_path`, as the handler configuration does not expose the path in logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
