### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,7 +30,7 @@ def configure_logging():
         log_dir.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         # Fall back to base directory if we cannot create the requested folder
-        print(f"WARNING: Could not create log directory '{log_dir}'. Logging to application directory instead. Error: {e}", file=sys.stderr)
+        print("WARNING: Could not create the configured log directory. Logging to application directory instead. Error: {}".format(e), file=sys.stderr)
         log_dir = BASE_DIR
     log_path = log_dir / "medical_automation.log"
 


### PR DESCRIPTION
Potential fix for [https://github.com/alebmorais/medical_automation/security/code-scanning/3](https://github.com/alebmorais/medical_automation/security/code-scanning/3)

To prevent accidental disclosure of potentially sensitive log directory paths, sanitize the error message to avoid directly printing the value of `log_dir`, especially when it is sourced from an environment variable. Instead, refer to it generically (e.g., `"a configured directory"` or `"the specified log directory"`), providing enough context to troubleshoot without exposing the actual path. Modify only the error message in line 33 of `server.py`—no functional changes elsewhere are needed.

If needed, consider logging the actual path at a higher debug level or only when a special "debug" mode is active, but never in a warning or error visible to users or standard logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
