### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/servers/medical_server.py
+++ b/servers/medical_server.py
@@ -44,7 +44,7 @@ def run_medical_server(db_path: str = None, host: str = '', port: int = None):
     server_address = (host, port)
     httpd = HTTPServer(server_address, handler_class)
     
-    print(f"✓ Servidor de frases médicas rodando em http://localhost:{port}")
+    print("✓ Servidor de frases médicas iniciado com sucesso.")
     
     # Start serving
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/alebmorais/medical_automation/security/code-scanning/2](https://github.com/alebmorais/medical_automation/security/code-scanning/2)

To fix this problem, the code should avoid logging user-supplied input such as the `port` parameter directly. The best fix, with minimal change in existing functionality, is to only log the fixed, default port from configuration (i.e., `MEDICAL_PORT`), or to simply print a generic server-running message that does not include the port or any user-supplied parameter at all. If including the port is truly useful for ops, at a minimum, you must ensure the value is validated and not just passed directly if tainted.

Specifically, in `servers/medical_server.py`, line 47, replace the `print` statement so that it no longer interpolates `port` directly. If it is important to show the port, only do so if it is validated as an integer and not from a potentially tainted source; otherwise, avoid including it altogether.

No new imports are required. No additions outside this file are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
