### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/import sqlite3.py
+++ b/import sqlite3.py
@@ -1,6 +1,7 @@
 import sqlite3
 from flask import Flask, jsonify, request
 import datetime
+import logging
 
 app = Flask(__name__)
 DATABASE = 'snippets.db'
@@ -37,7 +38,8 @@ def health_check():
         conn.close()
         db_status = "connected"
     except Exception as e:
-        db_status = f"error: {e}"
+        logging.exception("Database connection error in health_check")
+        db_status = "error: unable to connect"
     
     return jsonify({
         "status": "healthy",


### PR DESCRIPTION
Potential fix for [https://github.com/alebmorais/medical_automation/security/code-scanning/6](https://github.com/alebmorais/medical_automation/security/code-scanning/6)

To fix the information exposure vulnerability in the `/health` endpoint, avoid including exception details in the response sent to users. Instead, log the exception on the server—using Python's `logging` module—and return a generic error message (such as **"error: unable to connect"** or similar). 

Specific changes to make:  
- Add an import of `logging` at the top.
- In the exception handler in the `health_check()` function, log the exception using `logging.exception`, and set `db_status` to a safe, generic message.
- Do not include specific details from the exception object `e` in the response.

No changes to logic or handling for successful cases; database checks remain the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
